### PR TITLE
Babel: Use `babel-preset-react-app`.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,7 @@
 {
   "presets": [
     "kcd-scripts/babel",
-    "flow"
+    "react-app"
   ],
   "plugins": [
     "transform-flow-strip-types",

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: node_js
+node_js:
+  - "8"
+
+cache:
+  directories:
+    - node_modules
+
+install:
+  - npm install
+
+script:
+  - npm run test
+
+branches:
+  only:
+    - master

--- a/babel.js
+++ b/babel.js
@@ -1,7 +1,7 @@
 const kcdBabel = require('kcd-scripts/babel')
 
 module.exports = {
-  presets: kcdBabel.presets.concat(require.resolve('babel-preset-flow')),
+  presets: kcdBabel.presets.concat(require.resolve('babel-preset-react-app')),
   plugins: kcdBabel.plugins.concat(
     require.resolve('babel-plugin-transform-flow-strip-types'),
     require.resolve('babel-plugin-inline-svg')

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "precommit": "node src precommit",
     "postversion": "npm publish",
     "release": "np --no-yarn --no-publish",
-    "version": "npm run build"
+    "version": "npm run build",
+    "test": "npm run build"
   },
   "bin": {
     "zero": "dist/index.js"
@@ -43,13 +44,14 @@
     "babel-plugin-inline-svg": "1.0.0",
     "babel-plugin-module-resolver": "2.7.1",
     "babel-plugin-transform-flow-strip-types": "6.22.0",
+    "babel-preset-react-app": "3.1.2",
     "eslint": "4.19.1",
-    "eslint-loader": "2.0.0",
-    "eslint-plugin-import": "2.12.0",
-    "eslint-plugin-react": "7.9.1",
     "eslint-config-react-app": "2.1.0",
+    "eslint-loader": "2.0.0",
     "eslint-plugin-flowtype": "2.49.3",
+    "eslint-plugin-import": "2.12.0",
     "eslint-plugin-jsx-a11y": "5.1.1",
+    "eslint-plugin-react": "7.9.1",
     "eslint-scope": "3.7.1",
     "flow-bin": "0.75.0",
     "jest": "22.4.3",

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,13 @@
 #!/usr/bin/env node
+
+const args = process.argv.slice(2)
+const command = args[0]
+
+if (command && command.toLowerCase() === 'build') {
+  /* eslint dot-notation: 0 */
+  if (!process.env['BABEL_ENV']) {
+    process.env['BABEL_ENV'] = 'production'
+  }
+}
+
 require('kcd-scripts/dist/index')


### PR DESCRIPTION
## Babel: Use `babel-preset-react-app`.

This update updates Babel to use `preset-react-app` by default.
It also forces `BABEL_ENV=production` if build is triggered.