### PR TITLE
Update Husky

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "eslint-plugin-react": "7.9.1",
     "eslint-scope": "3.7.1",
     "flow-bin": "0.75.0",
+    "husky": "1.0.0-rc.13",
     "jest": "22.4.3",
     "jest-cli": "22.4.3",
     "kcd-scripts": "0.39.2"


### PR DESCRIPTION
## Update Husky

This update bumps `husky` to the `next` version to resolve precommit
issues stemming from `nvm` based node environments.