### PR TITLE
Babel 7: Fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ install:
 
 script:
   - npm run test
+  - npm run build
 
 branches:
   only:

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+const { jest: jestConfig } = require('./src/config')
+
+module.exports = Object.assign(jestConfig, {
+  coverageThreshold: null,
+})

--- a/jest.js
+++ b/jest.js
@@ -1,4 +1,4 @@
-const { jest: jestConfig } = require('kcd-scripts/config')
+const jestConfig = require('./dist/config/jest.config')
 
 module.exports = Object.assign(jestConfig, {
   testURL: 'http://localhost/',

--- a/package-lock.json
+++ b/package-lock.json
@@ -4322,7 +4322,7 @@
       "dependencies": {
         "resolve": {
           "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "resolved": "http://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
           "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
         }
       }
@@ -8741,7 +8741,7 @@
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "resolved": "http://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "requires": {
         "kind-of": "^3.0.2"
@@ -8803,7 +8803,7 @@
     },
     "is-data-descriptor": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "resolved": "http://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "requires": {
         "kind-of": "^3.0.2"
@@ -13094,7 +13094,7 @@
     },
     "path-browserify": {
       "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
       "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo="
     },
     "path-dirname": {
@@ -15133,7 +15133,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
@@ -16135,7 +16135,7 @@
     },
     "tty-browserify": {
       "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY="
     },
     "tunnel-agent": {
@@ -16203,7 +16203,7 @@
     },
     "underscore": {
       "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+      "resolved": "http://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
       "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
     },
     "unherit": {
@@ -16557,7 +16557,7 @@
     },
     "vm-browserify": {
       "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+      "resolved": "http://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
       "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
       "requires": {
         "indexof": "0.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/zero",
-  "version": "1.0.0",
+  "version": "1.0.1-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/zero",
-  "version": "1.0.0",
+  "version": "1.0.1-0",
   "public": true,
   "description": "Help Scout's zero config scripts",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "precommit": "node src pre-commit",
     "release": "np --no-yarn",
     "version": "npm run build",
-    "test": "CI=true node src test && npm run build"
+    "test": "CI=true npm run build && node src test"
   },
   "bin": {
     "zero": "dist/index.js"

--- a/src/config/babel-transform.js
+++ b/src/config/babel-transform.js
@@ -1,0 +1,5 @@
+const babelJest = require('babel-jest')
+
+module.exports = babelJest.createTransformer({
+  presets: [require.resolve('./babelrc')],
+})

--- a/src/config/babelrc.js
+++ b/src/config/babelrc.js
@@ -1,12 +1,7 @@
 const browserslist = require('browserslist')
 const semver = require('semver')
 
-const {
-  ifAnyDep,
-  parseEnv,
-  appDirectory,
-  pkg,
-} = require('kcd-scripts/dist/utils')
+const { ifAnyDep, parseEnv, appDirectory, pkg } = require('../utils')
 
 const { BABEL_ENV, NODE_ENV, BUILD_FORMAT } = process.env
 const isTest = (BABEL_ENV || NODE_ENV) === 'test'

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+  babel: require('./babelrc'),
+  jest: require('./jest.config'),
+}

--- a/src/config/jest.config.js
+++ b/src/config/jest.config.js
@@ -1,0 +1,38 @@
+const path = require('path')
+const { ifAnyDep, hasFile, hasPkgProp, fromRoot } = require('../utils')
+
+const here = p => path.join(__dirname, p)
+
+const useBuiltInBabelConfig = !hasFile('.babelrc') && !hasPkgProp('babel')
+
+const ignores = [
+  '/node_modules/',
+  '/fixtures/',
+  '/__tests__/helpers/',
+  '__mocks__',
+]
+
+const jestConfig = {
+  roots: [fromRoot('src')],
+  testEnvironment: ifAnyDep(['webpack', 'rollup', 'react'], 'jsdom', 'node'),
+  moduleFileExtensions: ['js', 'jsx', 'json', 'ts', 'tsx'],
+  collectCoverageFrom: ['src/**/*.+(js|jsx|ts|tsx)'],
+  testMatch: ['**/__tests__/**/*.+(js|jsx|ts|tsx)'],
+  testPathIgnorePatterns: [...ignores],
+  coveragePathIgnorePatterns: [...ignores, 'src/(umd|cjs|esm)-entry.js$'],
+  transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$'],
+  coverageThreshold: {
+    global: {
+      branches: 100,
+      functions: 100,
+      lines: 100,
+      statements: 100,
+    },
+  },
+}
+
+if (useBuiltInBabelConfig) {
+  jestConfig.transform = { '^.+\\.js$': here('./babel-transform') }
+}
+
+module.exports = jestConfig

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,3 @@
+const utils = require('kcd-scripts/dist/utils')
+
+module.exports = utils


### PR DESCRIPTION
## Babel 7: Fix

Follow up to: https://github.com/helpscout/zero/pull/5

This update plucks a wee bit more from `kcd-scripts` to ensure that Jest doesn't explode when compiling.

Note: The explosions happen when `kcd-scripts` is attempting to resolve `@babel/runtime`.