### PR TITLE
Build/Compile: Pass args to TypeScript and Babel

### DIFF
--- a/src/scripts/compile/babel.js
+++ b/src/scripts/compile/babel.js
@@ -1,9 +1,11 @@
+const args = process.argv.slice(2)
+
 exports.compileBabel = async () => {
   console.log('Compiling with Babel...')
 
   try {
     const { buildBabel } = require('../build/babel')
-    const result = await buildBabel()
+    const result = await buildBabel(args)
     process.exit(result)
   } catch (err) {
     console.log(err)

--- a/src/scripts/compile/typescript.js
+++ b/src/scripts/compile/typescript.js
@@ -1,3 +1,6 @@
+const args = process.argv.slice(2)
+const buildArgs = ['--no-clean', '--typescript', '--ts', '--tsc']
+
 exports.compileTypeScript = async () => {
   const { tsConfigSrc, hasTsConfig } = require('../../utils')
 
@@ -8,12 +11,19 @@ exports.compileTypeScript = async () => {
     process.exit(1)
   }
 
+  const tsArgs = args.filter(a => !buildArgs.includes(a))
+
   try {
-    console.log('Compiling with TypeScript...')
+    if (args.includes('--emitDeclarationOnly')) {
+      console.log('Compiling TypeScript declarations only...')
+    } else {
+      console.log('Compiling with TypeScript...')
+    }
+
     console.log(`Loading ${tsConfig}...`)
 
     const { execTypeScript } = require('../../exec/typescript')
-    const result = await execTypeScript()
+    const result = await execTypeScript(tsArgs)
 
     if (result === 1) {
       console.log('Issue compiling with TypeScript :(')


### PR DESCRIPTION
## Build/Compile: Pass args to TypeScript and Babel

This update fixes the issue where `--args` weren't correctly being passed
to the `zero build` command (for Babel and TS).

This allows for a command like this:

```
zero build && zero build --no-clean --ts --emitDeclarationOnly
```

It compiles TS with Babel, and the `.d.ts` files with `tsc`