### PR TITLE
Babel: Build - Add .js,.jsx extensions

### DIFF
--- a/src/scripts/build/babel.js
+++ b/src/scripts/build/babel.js
@@ -28,7 +28,9 @@ exports.buildBabel = async () => {
     const outDir = useSpecifiedOutDir ? [] : ['--out-dir', 'dist']
 
     // Add TypeScript support!
-    const extensions = ['--extensions', '.ts,.tsx']
+    const extensions = args.includes('--extensions')
+      ? []
+      : ['--extensions', '.js,.jsx,.ts,.tsx']
 
     const result = spawn.sync(
       resolveBin('@babel/cli', { executable: 'babel' }),


### PR DESCRIPTION
## Babel: Build - Add .js,.jsx extensions

This update fixes the bug where `zero build` was not correctly targeting
`.js` and `.jsx` files